### PR TITLE
fix: gnosis safes 1.3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dist/
 _build/
 poetry.lock
+.hypothesis/

--- a/ape_safe.py
+++ b/ape_safe.py
@@ -15,6 +15,19 @@ from gnosis.safe.multi_send import MultiSend, MultiSendOperation, MultiSendTx
 from gnosis.safe.safe_tx import SafeTx
 
 
+transaction_service = {
+    1: 'https://safe-transaction.mainnet.gnosis.io',
+    4: 'https://safe-transaction.rinkeby.gnosis.io',
+    5: 'https://safe-transaction.goerli.gnosis.io',
+    56: 'https://safe-transaction.bsc.gnosis.io',
+    100: 'https://safe-transaction.xdai.gnosis.io',
+    137: 'https://safe-transaction.polygon.gnosis.io',
+    246: 'https://safe-transaction.ewc.gnosis.io',
+    42161: 'https://safe-transaction.arbitrum.gnosis.io',
+    73799: 'https://safe-transaction.volta.gnosis.io',
+}
+
+
 class ExecutionFailure(Exception):
     pass
 
@@ -27,14 +40,14 @@ class ApeSafe(Safe):
     base_url = 'https://safe-transaction.mainnet.gnosis.io'
     multisend = '0x40A2aCCbd92BCA938b02010E17A5b8929b49130D'
 
-    def __init__(self, address, ethereum_client: EthereumClient = None):
+    def __init__(self, address):
         """
         Create an ApeSafe from an address or a ENS name and use a default connection.
         """
         if not web3.isChecksumAddress(address):
             address = web3.ens.resolve(address)
-        if ethereum_client is None:
-            ethereum_client = EthereumClient()
+        ethereum_client = EthereumClient(web3.provider.endpoint_uri)
+        self.base_url = transaction_service[chain.id]
         super().__init__(address, ethereum_client)
 
     def __str__(self):

--- a/ape_safe.py
+++ b/ape_safe.py
@@ -25,7 +25,7 @@ class ApiError(Exception):
 
 class ApeSafe(Safe):
     base_url = 'https://safe-transaction.mainnet.gnosis.io'
-    multisend = '0x8D29bE29923b68abfDD21e541b9374737B49cdAD'
+    multisend = '0x40A2aCCbd92BCA938b02010E17A5b8929b49130D'
 
     def __init__(self, address, ethereum_client: EthereumClient = None):
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ape-safe"
-version = "0.1.4"
+version = "0.2.0"
 description = "Build complex Gnosis Safe transactions and safely preview them in a forked environment."
 authors = ["banteg <banteeg@gmail.com>"]
 license = "MIT"
@@ -8,8 +8,8 @@ repository = "https://github.com/banteg/ape-safe"
 readme = "readme.md"
 
 [tool.poetry.dependencies]
-python = "^3.7"
-eth-brownie = "^1.13.2"
+python = "^3.8"
+eth-brownie = "^1.15.0"
 gnosis-py = "^3.1.13"
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "readme.md"
 [tool.poetry.dependencies]
 python = "^3.7"
 eth-brownie = "^1.13.2"
-gnosis-py = "^2.7.14"
+gnosis-py = "^3.1.13"
 
 [tool.poetry.dev-dependencies]
 


### PR DESCRIPTION
Polygon safes are 1.3.0. Without upgrading gnosis-py, ape safe doesn't work correctly.