### PR TITLE
feat: hardware wallet support via frame signer

### DIFF
--- a/ape_safe.py
+++ b/ape_safe.py
@@ -184,10 +184,9 @@ class ApeSafe(Safe):
         """
         Submit a signature to a transaction service.
         """
-        url = urljoin(self.base_url, f'/multisig-transactions/{safe_tx.safe_tx_hash.hex()}/confirmations/')
+        url = urljoin(self.base_url, f'/api/v1/multisig-transactions/{safe_tx.safe_tx_hash.hex()}/confirmations/')
         data = {'signature': HexBytes(signature).hex()}
         response = requests.post(url, json=data)
-        print(response.text)
         if not response.ok:
             raise ApiError(f'Error posting signature: {response.text}')
 

--- a/ape_safe.py
+++ b/ape_safe.py
@@ -178,7 +178,18 @@ class ApeSafe(Safe):
         }
         response = requests.post(url, json=data)
         if not response.ok:
-            raise ApiError(f'Error posting transaction: {response.content}')
+            raise ApiError(f'Error posting transaction: {response.text}')
+
+    def post_signature(self, safe_tx: SafeTx, signature: bytes):
+        """
+        Submit a signature to a transaction service.
+        """
+        url = urljoin(self.base_url, f'/multisig-transactions/{safe_tx.safe_tx_hash.hex()}/confirmations/')
+        data = {'signature': HexBytes(signature).hex()}
+        response = requests.post(url, json=data)
+        print(response.text)
+        if not response.ok:
+            raise ApiError(f'Error posting signature: {response.text}')
 
     def estimate_gas(self, safe_tx: SafeTx) -> int:
         """

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,0 +1,20 @@
+Changelog
+=========
+
+0.3.0
+-----
+
+- hardware wallet support via frame
+- submit signatures to transaction service
+- retrieve pending transactions from transaction service
+- execute signed transactions
+- convert confirmations to signatures
+- expanded documentation about signing
+
+0.2.0
+-----
+
+- add support for safe contracts 1.3.0
+- switch to multicall 1.3.0 call only
+- support multiple networks
+- autodetect transaction service from chain id

--- a/docs/detailed.rst
+++ b/docs/detailed.rst
@@ -37,16 +37,16 @@ Play around the same way you would do with a normal account:
     >>> vault = safe.contract('0xFe39Ce91437C76178665D64d7a2694B0f6f17fE3')
 
     # Work our way towards having a vault balance
-    >>> dai_amount = dai.balanceOf(safe.account)
+    >>> dai_amount = dai.balanceOf(safe)
     >>> dai.approve(zap, dai_amount)
     >>> amounts = [0, dai_amount, 0, 0]
     >>> mint_amount = zap.calc_token_amount(amounts, True)
     >>> zap.add_liquidity(amounts, mint_amount * 0.99)
     >>> lp.approve(vault, 2 ** 256 - 1)
     >>> vault.depositAll()
-    >>> vault.balanceOf(safe.account)
+    >>> vault.balanceOf(safe)
     2609.5479641693646
-    
+
     # Combine transaction history into a multisend transaction
     >>> safe_tx = safe.multisend_from_receipts()
 
@@ -58,12 +58,24 @@ Play around the same way you would do with a normal account:
     # including a detailed call trace, courtesy of Brownie
     >>> safe.preview(safe_tx, call_trace=True)
 
-    # Sign a transaction
-    >>> signed_tx = safe.sign_transaction(safe_tx)
-
     # Post it to the transaction service
     # Prompts for a signature if needed
     >>> safe.post_transaction(safe_tx)
 
-    # You can also preview side effects of pending transactions
+    # Post an additional confirmation to the transaction service
+    >>> signtature = safe.sign_transaction(safe_tx)
+    >>> safe.post_signature(safe_tx, signature)
+
+    # Retrieve pending transactions from the transaction service
+    >>> safe.pending_transactions
+    
+    # Preview the side effects of all pending transactions
     >>> safe.preview_pending()
+
+    # Execute the transactions with enough signatures
+    >>> network.priority_fee('2 gwei')
+    >>> signer = safe.get_signer('ape')
+    >>>
+    >>> for tx in safe.pending_transactions:
+    >>>     receipt = safe.execute_transaction(safe_tx, signer)
+    >>>     receipt.info()

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,7 +4,7 @@ Ape Safe: Gnosis Safe tx builder
 Ape Safe allows you to iteratively build complex multi-step Gnosis Safe transactions and safely preview their side effects from the convenience of a locally forked mainnet environment.
 
 It is powered by Brownie_ and builds upon GnosisPy_, extending it with additional capabilities.
-This tool has been informally known as Chief Multisig Officer and it has been used at Yearn_ to prepare complex transactions with great success.
+This tool has been informally known as Chief Multisig Officer at Yearn_ and has been used to prepare complex transactions with great success.
 
 .. toctree::
    :maxdepth: 2
@@ -15,6 +15,7 @@ This tool has been informally known as Chief Multisig Officer and it has been us
    signing
    detailed
    useful
+   changelog
    ape_safe
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,7 +12,9 @@ This tool has been informally known as Chief Multisig Officer and it has been us
    intro
    quickstart
    install
+   signing
    detailed
+   useful
    ape_safe
 
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -1,7 +1,7 @@
 Installation
 ============
 
-You will need Python and pip installed, as well as Brownie_ and `Ganache CLI`_ for ``mainnet-fork`` functionality.
+You will need Python and pip installed, as well as Brownie_ and either of `Ganache CLI`_ or Hardhat_ for the forked network functionality.
 Make sure you have `Brownie networks`_ configured correctly.
 
 Then you can simply:
@@ -12,5 +12,6 @@ Then you can simply:
 
 
 .. _Brownie: https://eth-brownie.readthedocs.io/en/latest/install.html
+.. _Hardhat: https://hardhat.org/getting-started/#installation
 .. _Brownie networks: https://eth-brownie.readthedocs.io/en/latest/network-management.html
 .. _Ganache CLI: https://github.com/trufflesuite/ganache-cli

--- a/docs/signing.rst
+++ b/docs/signing.rst
@@ -1,0 +1,53 @@
+Signing
+=======
+
+Several options for signing transactions are available in ApeSafe, including support for hardware wallets.
+
+Local accounts
+--------------
+
+Import a private key or a keystore into Brownie to use it with ApeSafe. Brownie accounts are encrypted as .json keystore at rest. See `Account management`_ section of the Brownie docs for details.
+
+.. code-block:: bash
+
+    # Import a private key
+    $ brownie accounts new ape
+    Enter the private key you wish to add:
+
+    # Import a .json keystore
+    brownie accounts import ape keystore.json
+
+Gnosis Safe API won't accept a transaction without signatures unless you are `a delegate`_. Local account is the default signing option when you send a transaction. ApeSafe will prompt you for an account and Brownie will prompt you for a password.
+
+You can also explicitly sign a transaction with a specific account to skip the first prompt:
+
+.. code-block:: python
+
+    >>> safe.sign_transaction(safe_tx, 'ape')
+
+If you prefer to manage accounts outside Brownie, e.g. use a seed phrase, you can pass a ``LocalAccount`` instance:
+
+.. code-block:: python
+
+    >>> from eth_account import Account
+    >>> key = Account.from_mnemonic('safe grape tape escape...')
+    >>> safe.sign_transaction(safe_tx, key)
+
+Frame
+-----
+
+If you wish to use a hardware wallet, your best option is Frame_. It supports all Ledger, Trezor, and Grid+ models. You can also use with with keystore accounts called Ring Signers in Frame.
+
+To sign a transaction using Frame, select an account in Frame and do this:
+
+.. code-block:: python
+
+    >>> safe.sign_with_frame(safe_tx)
+
+
+Frame exposes an RPC connection at ``http://127.0.0.1:1248`` and exposes the currently selected account as ``eth_accounts[0]``. ApeSafe sends the payload as ``eth_signTypedData_v4``.
+
+
+.. _Account management: https://eth-brownie.readthedocs.io/en/latest/account-management.html
+.. _Frame: https://frame.sh/
+.. _`a delegate`: https://safe-transaction.gnosis.io/

--- a/docs/signing.rst
+++ b/docs/signing.rst
@@ -1,12 +1,18 @@
 Signing
 =======
 
-Several options for signing transactions are available in ApeSafe, including support for hardware wallets.
+Several options for signing transactions are available in Ape Safe, including support for hardware wallets.
+
+Signatures are required, Gnosis `transaction service`_ will only accept a transaction with an owner signature or from `a delegate`_.
 
 Local accounts
 --------------
 
-Import a private key or a keystore into Brownie to use it with ApeSafe. Brownie accounts are encrypted as .json keystore at rest. See `Account management`_ section of the Brownie docs for details.
+This is the default signing method when you send a transaction.
+
+Import a private key or a keystore into Brownie to use it with Ape Safe.
+Brownie accounts are encrypted at rest as .json keystores.
+See also Brownie's `Account management`_ documentation.
 
 .. code-block:: bash
 
@@ -15,15 +21,18 @@ Import a private key or a keystore into Brownie to use it with ApeSafe. Brownie 
     Enter the private key you wish to add:
 
     # Import a .json keystore
-    brownie accounts import ape keystore.json
+    $ brownie accounts import ape keystore.json
 
-Gnosis Safe API won't accept a transaction without signatures unless you are `a delegate`_. Local account is the default signing option when you send a transaction. ApeSafe will prompt you for an account and Brownie will prompt you for a password.
-
-You can also explicitly sign a transaction with a specific account to skip the first prompt:
+Ape Safe will prompt you for an account (unless supplied as an argument) and Brownie will prompt you for a password.
 
 .. code-block:: python
 
+    >>> safe.sign_transaction(safe_tx)
+    signer (ape, safe): ape
+    Enter password for "ape":
+    
     >>> safe.sign_transaction(safe_tx, 'ape')
+    Enter password for "ape":
 
 If you prefer to manage accounts outside Brownie, e.g. use a seed phrase, you can pass a ``LocalAccount`` instance:
 
@@ -36,18 +45,19 @@ If you prefer to manage accounts outside Brownie, e.g. use a seed phrase, you ca
 Frame
 -----
 
-If you wish to use a hardware wallet, your best option is Frame_. It supports all Ledger, Trezor, and Grid+ models. You can also use with with keystore accounts called Ring Signers in Frame.
+If you wish to use a hardware wallet, your best option is Frame_. It supports Ledger, Trezor, and Lattice. You can also use with with keystore accounts, they are called Ring Signers in Frame.
 
-To sign a transaction using Frame, select an account in Frame and do this:
+To sign, select an account in Frame and do this:
 
 .. code-block:: python
 
     >>> safe.sign_with_frame(safe_tx)
 
 
-Frame exposes an RPC connection at ``http://127.0.0.1:1248`` and exposes the currently selected account as ``eth_accounts[0]``. ApeSafe sends the payload as ``eth_signTypedData_v4``.
+Frame exposes an RPC connection at ``http://127.0.0.1:1248`` and exposes the currently selected account as ``eth_accounts[0]``. Ape Safe sends the payload as ``eth_signTypedData_v4``, which must be supported by your signer device.
 
 
+.. _`transaction service`: https://safe-transaction.gnosis.io/
+.. _`a delegate`: https://safe-transaction.gnosis.io/
 .. _Account management: https://eth-brownie.readthedocs.io/en/latest/account-management.html
 .. _Frame: https://frame.sh/
-.. _`a delegate`: https://safe-transaction.gnosis.io/

--- a/docs/useful.rst
+++ b/docs/useful.rst
@@ -1,0 +1,7 @@
+Useful links
+============
+
+- `Cowswap trades with Gnosis safe`_ by Poolpi Tako
+
+
+.. _`Cowswap trades with Gnosis safe`: https://hackmd.io/@2jvugD4TTLaxyG3oLkPg-g/H14TQ1Omt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "readme.md"
 [tool.poetry.dependencies]
 python = "^3.8"
 eth-brownie = "^1.17.0"
-gnosis-py = "^3.5.0"
+gnosis-py = "^3.6.0"
 
 [tool.poetry.dev-dependencies]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ape-safe"
-version = "0.2.2"
+version = "0.3.0"
 description = "Build complex Gnosis Safe transactions and safely preview them in a forked environment."
 authors = ["banteg <banteeg@gmail.com>"]
 license = "MIT"
@@ -9,8 +9,8 @@ readme = "readme.md"
 
 [tool.poetry.dependencies]
 python = "^3.8"
-eth-brownie = "^1.16.3"
-gnosis-py = "^3.2.2"
+eth-brownie = "^1.17.0"
+gnosis-py = "^3.5.0"
 
 [tool.poetry.dev-dependencies]
 


### PR DESCRIPTION
Add ability to sign Safe transactions using Ledger, Trezor and Lattice1 via Frame.

Tested on Ethereum Mainnet with Ledger Nano X.

New API: 
- `get_signer()`
- `sign_with_frame(safe_tx)`
- `post_signature(safe_tx, signature_`
- `pending_transactions`
- `confirmations_to_signatures(confirmations)`
- `execute_transaction`

Some specific combinations I want tested:
- [ ] safe on any network but eth mainnet which has a ledger as owner (ledger doesn't support eip155 and i want to see if i implemented the fix for it correctly)
- [ ] safe on any network with any trezor model as owner
- [ ] safe on any network with lattice1 as owner
