### PR TITLE
feat: add Trezor signing support (through trezorlib)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ readme = "readme.md"
 python = "^3.8"
 eth-brownie = "^1.17.0"
 gnosis-py = "^3.6.0"
+trezor = "^0.12.4"
 
 [tool.poetry.dev-dependencies]
 


### PR DESCRIPTION
Added ability to create `eth_sign` SafeTx signatures with trezorlib. Adds new function `sign_with_trezor(safe_tx, derivation_path, use_passphrase)`

Passphrase support is kind of rudimentary; I believe it might not work on the Trezor One because you can't enter a passphrase on-device with it. We could probably do on-host passphrase input though. Otherwise, it defaults to no passphrase (and skips any passphrase prompts), which *will* probably work on a T1

Tested w/ a Trezor T on fw v2.4.2.

(also, worth noting that EIP-712 support is now in master for TT; we can probably add `signTypedData` support too)

(would also appreciate if someone with a T1 could test it out)