### PR TITLE
chore: update gnosis-py dependency to new safe-eth-py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "readme.md"
 [tool.poetry.dependencies]
 python = "^3.8"
 eth-brownie = "^1.17.0"
-gnosis-py = "^3.7.5"
+safe-eth-py = "^4.0.1"
 trezor = "^0.13.0"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
Fixes https://github.com/banteg/ape-safe/issues/33