### PR TITLE
chore: update safe global api urls

### DIFF
--- a/ape_safe.py
+++ b/ape_safe.py
@@ -43,7 +43,7 @@ transaction_service = {
     42161: 'https://safe-transaction-arbitrum.safe.global',
     43114: 'https://safe-transaction-avalanche.safe.global',
     73799: 'https://safe-transaction-volta.safe.global',
-    1313161554: 'https://safe-transaction-aurora.safe.global/',
+    1313161554: 'https://safe-transaction-aurora.safe.global',
 }
 
 

--- a/ape_safe.py
+++ b/ape_safe.py
@@ -31,19 +31,19 @@ multisends = {
     43114: '0x998739BFdAAdde7C933B942a68053933098f9EDa'
 }
 transaction_service = {
-    1: 'https://safe-transaction.mainnet.gnosis.io',
-    4: 'https://safe-transaction.rinkeby.gnosis.io',
-    5: 'https://safe-transaction.goerli.gnosis.io',
+    1: 'https://safe-transaction-mainnet.safe.global',
+    5: 'https://safe-transaction-goerli.safe.global',
     10: 'https://safe-transaction-optimism.safe.global',
-    56: 'https://safe-transaction.bsc.gnosis.io',
-    100: 'https://safe-transaction.xdai.gnosis.io',
-    137: 'https://safe-transaction.polygon.gnosis.io',
+    56: 'https://safe-transaction-bsc.safe.global',
+    100: 'https://safe-transaction-gnosis-chain.safe.global',
+    137: 'https://safe-transaction-polygon.safe.global',
+    246: 'https://safe-transaction-ewc.safe.global',
     250: 'https://safe-txservice.fantom.network',
-    246: 'https://safe-transaction.ewc.gnosis.io',
     288: 'https://safe-transaction.mainnet.boba.network',
     42161: 'https://safe-transaction-arbitrum.safe.global',
     43114: 'https://safe-transaction-avalanche.safe.global',
-    73799: 'https://safe-transaction.volta.gnosis.io',
+    73799: 'https://safe-transaction-volta.safe.global',
+    1313161554: 'https://safe-transaction-aurora.safe.global/',
 }
 
 


### PR DESCRIPTION
old docs here, but urls redirect to the new ones: https://docs.gnosis-safe.io/backend/available-services#safe-transaction-service

rinkeby has been deprecated